### PR TITLE
Fix some issues and greatly enhance keyboard visual aspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,19 @@ import piano_visualizer
 # Create a piano with a midi file(s)
 piano = piano_visualizer.Piano(["/path/to/your/midi/file.mid"])
 
-# You can use options to change the visual rendering:
-# `color` of notes and played keys can be "rainbow" (default) or an RGB tuple
-# `no_gradient` uses flat color instead of gradient (default) on played keys
-# `realistic_render` option adds round border to bottom of white keys and bevel to black keys
+## Piano options:
+# You can customize the visual rendering to suit your preferences:
+# - `color` of notes and played keys can be "rainbow" (default) or an RGB tuple
+# - `no_gradient` uses flat color instead of gradient (default) on played keys
+# - `realistic_render` option adds round border to bottom of white keys and bevel to black keys
 # piano = piano_visualizer.Piano(midis=["/path/to/your/midi/file.mid"], color=(255, 0, 0), no_gradient=True, realistic_render=True)
 
 # Create a video with resolution/fps
 video = piano_visualizer.Video((1920, 1080), 30)
+
+## Video options:
+# - `keyboard_crop`: if True, the video height will be automatically adjusted to fit only the keyboard (no falling notes area, only the keys are visible)
+# video = piano_visualizer.Video((1920, 1080), 30, keyboard_crop=True)
 
 # Add piano to video
 video.add_piano(piano)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A python library that allows you to export a video in which a piano is playing t
 
 -   Export a video of a custom midi file
 -   Easy interface
+-   Visual rendering options
 -   Multi-core export
 -   Multiple piano support
 -   Multiple midi support
@@ -32,6 +33,12 @@ import piano_visualizer
 
 # Create a piano with a midi file(s)
 piano = piano_visualizer.Piano(["/path/to/your/midi/file.mid"])
+
+# You can use options to change the visual rendering:
+# `color` of notes and played keys can be "rainbow" (default) or an RGB tuple
+# `no_gradient` uses flat color instead of gradient (default) on played keys
+# `realistic_render` option adds round border to bottom of white keys and bevel to black keys
+# piano = piano_visualizer.Piano(midis=["/path/to/your/midi/file.mid"], color=(255, 0, 0), no_gradient=True, realistic_render=True)
 
 # Create a video with resolution/fps
 video = piano_visualizer.Video((1920, 1080), 30)

--- a/piano_visualizer/__init__.py
+++ b/piano_visualizer/__init__.py
@@ -38,8 +38,8 @@ class Video:
         Compute and return piano dimensions for rendering and block fall calculations.
         Returns a dict with keys: whitekey_height, blackkey_height, block_fall_height, etc.
         """
-        height = self.resolution[1]
-        width = self.resolution[0]
+        height = self.requested_resolution[1]
+        width = self.requested_resolution[0]
         min_height = height / 12
         p_height = height / len(self.pianos)
         num_white_keys = 52
@@ -69,16 +69,23 @@ class Video:
             'p_width': width,
         }
 
-    def __init__(self, resolution=(1920, 1080), fps=30, start_offset=0, end_offset=0):
-        self.resolution = resolution
+    def __init__(self, resolution=(1920, 1080), fps=30, start_offset=0, end_offset=0, keyboard_crop=False):
+        self.requested_resolution = resolution
         self.fps = fps
         self.start_offset = start_offset
         self.end_offset = end_offset
         self.audio = ["default"]
         self.pianos = []
+        self.keyboard_crop = keyboard_crop
+        self.resolution = resolution
 
     def add_piano(self, piano):
         self.pianos.append(piano)
+        # Adjust resolution if keyboard_crop is enabled
+        if self.keyboard_crop:
+            dims = self.get_piano_dimensions()
+            cropped_height = int(dims['whitekey_height'] * len(self.pianos))
+            self.resolution = (self.requested_resolution[0], cropped_height)
 
     def set_audio(self, audio, overwrite=True):
         if overwrite:
@@ -323,9 +330,14 @@ class Video:
         surf.fill((0, 0, 0, 0))
         dims = self.get_piano_dimensions()
         for i, piano in enumerate(self.pianos):
-            p_y = dims['p_height'] * i
+            if getattr(self, 'keyboard_crop', False):
+                p_y = 0
+                p_height = dims['whitekey_height']
+            else:
+                p_y = dims['p_height'] * i
+                p_height = dims['p_height']
             piano.render(
-                surf, frame, p_y, dims['p_width'], dims['p_height'],
+                surf, frame, p_y, dims['p_width'], p_height,
                 dims['whitekey_height'], dims['blackkey_height'],
                 dims['whitekey_width'], dims['blackkey_width'],
                 dims['gap'], dims['blackkey_x_offsets'], dims['margin']

--- a/piano_visualizer/__init__.py
+++ b/piano_visualizer/__init__.py
@@ -73,7 +73,9 @@ class Video:
                     pass
                 surf = pygame.surfarray.pixels3d(self.render(
                     frame-self.start_offset)).swapaxes(0, 1)
-                video.write(surf)
+                # Convert from RGB to BGR for OpenCV
+                surf_bgr = cv2.cvtColor(surf, cv2.COLOR_RGB2BGR)
+                video.write(surf_bgr)
             video.release()
             cv2.destroyAllWindows()
 
@@ -164,7 +166,9 @@ class Video:
                 for frame in tqdm(range(min_frame, max_frame + self.start_offset + self.end_offset + 1), desc="Exporting", unit="frames"):
                     surf = pygame.surfarray.pixels3d(self.render(
                         frame-self.start_offset)).swapaxes(0, 1)
-                    video.write(surf)
+                    # Convert from RGB to BGR for OpenCV
+                    surf_bgr = cv2.cvtColor(surf, cv2.COLOR_RGB2BGR)
+                    video.write(surf_bgr)
 
             video.release()
             cv2.destroyAllWindows()
@@ -351,7 +355,9 @@ class Piano:
             return counter*(wwidth + gap)
 
     def get_rainbow(self, x, width):
-        return hsv_to_rgb(((x/width)*255, 255, 255))
+        rgb = hsv_to_rgb(((x/width)*255, 255, 255))
+        # invert values to preserve the same final rainbow as before fixing BGR format for OpenCV
+        return (rgb[2], rgb[1], rgb[0])
 
     def add_midi(self, path):
         self.midis.append(path)

--- a/piano_visualizer/__init__.py
+++ b/piano_visualizer/__init__.py
@@ -365,7 +365,7 @@ class Piano:
                 frame = 0
                 start_keys = [None] * 88
                 for msg in track:
-                    frame += msg.time/midi.ticks_per_beat * tempo/1675000 * self.fps
+                    frame += (msg.time * tempo / midi.ticks_per_beat / 1_000_000) * self.fps
                     if msg.is_meta:
                         if msg.type == "set_tempo":
                             tempo = msg.tempo

--- a/piano_visualizer/__init__.py
+++ b/piano_visualizer/__init__.py
@@ -32,8 +32,43 @@ from random_utils.funcs import crash
 from pydub import AudioSegment
 from tqdm import tqdm
 
-
 class Video:
+    def get_piano_dimensions(self):
+        """
+        Compute and return piano dimensions for rendering and block fall calculations.
+        Returns a dict with keys: whitekey_height, blackkey_height, block_fall_height, etc.
+        """
+        height = self.resolution[1]
+        width = self.resolution[0]
+        min_height = height / 12
+        p_height = height / len(self.pianos)
+        num_white_keys = 52
+        gap = 2
+        # calculates keys dimensions based on actual piano proportions and video resolution
+        total_seps = (num_white_keys - 1) * gap
+        ideal_keys_width = width - total_seps
+        whitekey_width = int(ideal_keys_width // num_white_keys)
+        actual_whitekey_height = whitekey_width * 6
+        whitekey_height = min(actual_whitekey_height, max(min_height, height / (len(self.pianos) + 2)))
+        blackkey_width = whitekey_width * 0.65
+        blackkey_height = whitekey_height * 0.65
+        block_fall_height = p_height - whitekey_height
+        blackkey_x_offsets = [0, 0.65, 0, 0.35, 0, 0, 0.75, 0, 0.5, 0, 0.3, 0]
+        used_width = whitekey_width * num_white_keys + total_seps
+        margin = (width - used_width) // 2
+        return {
+            'whitekey_height': whitekey_height,
+            'blackkey_height': blackkey_height,
+            'block_fall_height': block_fall_height,
+            'whitekey_width': whitekey_width,
+            'blackkey_width': blackkey_width,
+            'gap': gap,
+            'blackkey_x_offsets': blackkey_x_offsets,
+            'margin': margin,
+            'p_height': p_height,
+            'p_width': width,
+        }
+
     def __init__(self, resolution=(1920, 1080), fps=30, start_offset=0, end_offset=0):
         self.resolution = resolution
         self.fps = fps
@@ -87,19 +122,39 @@ class Video:
             print(f"Piano {i+1} done")
         print("All pianos done.")
 
-        min_frame, max_frame = min(self.pianos, key=lambda x: x.get_min_time()).get_min_time(
-        ), max(self.pianos, key=lambda x: x.get_max_time()).get_max_time()
+        # Calculate MIDI time boundaries and export range
+        min_frame = min(self.pianos, key=lambda x: x.get_min_time()).get_min_time()
+        max_note_frame = max(self.pianos, key=lambda x: x.get_max_time()).get_max_time()
+        # True end of MIDI (including trailing silence)
+        midi_end_frame = max(
+            max((note['end'] for note in piano.notes), default=0) for piano in self.pianos
+        )
 
-        max_frame = int(frac_frames * (max_frame - min_frame) + min_frame)
-        frames = int(max_frame - min_frame)
+        # Block fall duration (frames for last notes to reach the keyboard)
+        if self.pianos:
+            piano = self.pianos[0]
+            dims = self.get_piano_dimensions()
+            block_fall_height = dims['block_fall_height']
+            block_speed = getattr(piano, 'block_speed', 200)
+            block_fall_duration = int(block_fall_height / (block_speed / self.fps))
+        else:
+            block_fall_duration = 0
 
-        print("-"*50)
-        print("Exporting video:")
+        # Silence before first note (in frames)
+        silence_start = min_frame
+        # Silence after last note (in frames)
+        silence_end = max(0, midi_end_frame - max_note_frame)
+
+        # Export range: from frame 0 to the end of the last block fall and trailing silence
+        export_start = 0
+        export_end = int(silence_start + (frac_frames * (max_note_frame - min_frame)) + block_fall_duration + silence_end + self.start_offset + self.end_offset)
+        frames = export_end - export_start + 1
         print(f"  Resolution: {' by '.join(map(str, self.resolution))}")
         print(f"  FPS: {self.fps}")
+
+
         print(f"  Frames: {frames}")
-        print(
-            f"  Duration: {int((frames+self.start_offset+self.end_offset)/self.fps)} secs\n")
+        print(f"  Duration: {int(frames/self.fps)} secs\n")
 
         time_start = time.time()
 
@@ -108,6 +163,7 @@ class Video:
         try:
             video = cv2.VideoWriter(os.path.join(export_dir, "video.mp4"), cv2.VideoWriter_fourcc(
                 *"MPEG"), self.fps, self.resolution)
+
             if num_cores > 1:
                 if num_cores >= multiprocessing.cpu_count():
                     print("High chance of computer freezing")
@@ -123,19 +179,21 @@ class Video:
                             num_cores = int(input("New core count: "))
                 num_cores = min(num_cores, multiprocessing.cpu_count())
                 processes = []
-                curr_frame = 0
-                frame_inc = (frames + self.start_offset + self.end_offset) / num_cores
+                curr_frame = export_start
+                frame_inc = (frames) / num_cores
 
                 print(
                     f"Exporting {int(frame_inc)} on each of {num_cores} cores...")
 
                 for i in range(num_cores):
+                    start_f = int(curr_frame)
+                    end_f = int(min(export_end, curr_frame + frame_inc - 1))
                     p = multiprocessing.Process(target=quick_export, args=(
-                        i, int(curr_frame), int(curr_frame + frame_inc)))
+                        i, start_f, end_f))
                     p.start()
                     processes.append(p)
 
-                    curr_frame += frame_inc + 1
+                    curr_frame += frame_inc
 
                 time.sleep(.1)  # Wait for all processes to start.
 
@@ -152,7 +210,7 @@ class Video:
 
                 videos = [os.path.join(
                     export_dir, f"video{c}.mp4") for c in range(num_cores)]
-                with tqdm(total=frames+self.start_offset+self.end_offset+num_cores, unit="frames", desc="Concatenating") as t:
+                with tqdm(total=frames+num_cores, unit="frames", desc="Concatenating") as t:
                     for v in videos:
                         curr_v = cv2.VideoCapture(v)
                         while curr_v.isOpened():
@@ -163,9 +221,11 @@ class Video:
                             t.update()
 
             else:
-                for frame in tqdm(range(min_frame, max_frame + self.start_offset + self.end_offset + 1), desc="Exporting", unit="frames"):
+                # Export all frames including the block fall duration
+                for frame in tqdm(range(export_start, export_end + 1), desc="Exporting", unit="frames"):
+                    # Shift all rendering by the silence at the start
                     surf = pygame.surfarray.pixels3d(self.render(
-                        frame-self.start_offset)).swapaxes(0, 1)
+                        frame - silence_start - self.start_offset)).swapaxes(0, 1)
                     # Convert from RGB to BGR for OpenCV
                     surf_bgr = cv2.cvtColor(surf, cv2.COLOR_RGB2BGR)
                     video.write(surf_bgr)
@@ -261,29 +321,15 @@ class Video:
     def render(self, frame):
         surf = pygame.Surface(self.resolution, pygame.SRCALPHA)
         surf.fill((0, 0, 0, 0))
-        width, height = self.resolution
-        min_height = height/12
-        p_height = height/len(self.pianos)
-        p_width = width
-        num_white_keys = 52
-        gap = 2
-        # calculates keys dimensions based on actual piano proportions and video resolution
-        total_seps = (num_white_keys - 1) * gap
-        ideal_keys_width = width - total_seps
-        whitekey_width = int(ideal_keys_width // num_white_keys)
-        actual_whitekey_height = whitekey_width * 6
-        whitekey_height = min(actual_whitekey_height, max(min_height, height/(len(self.pianos)+2)))
-        blackkey_width = whitekey_width * 0.65
-        blackkey_height = whitekey_height * 0.65
-        blackkey_x_offsets = [0, 0.65, 0, 0.35, 0, 0, 0.75, 0, 0.5, 0, 0.3, 0]
-        used_width = whitekey_width * num_white_keys + total_seps
-        margin = (width - used_width) // 2
-
+        dims = self.get_piano_dimensions()
         for i, piano in enumerate(self.pianos):
-            p_y = p_height * i
-            piano.render(surf, frame, p_y, p_width, p_height, whitekey_height,
-                         blackkey_height, whitekey_width, blackkey_width, gap, blackkey_x_offsets, margin)
-
+            p_y = dims['p_height'] * i
+            piano.render(
+                surf, frame, p_y, dims['p_width'], dims['p_height'],
+                dims['whitekey_height'], dims['blackkey_height'],
+                dims['whitekey_width'], dims['blackkey_width'],
+                dims['gap'], dims['blackkey_x_offsets'], dims['margin']
+            )
         return surf
 
 class Piano:

--- a/piano_visualizer/__init__.py
+++ b/piano_visualizer/__init__.py
@@ -219,9 +219,19 @@ class Video:
                 if os.path.isfile(path):
                     os.remove(path)
                 ffmpeg.run(video)
+
             else:
                 print("Skipping music...")
-                os.rename(os.path.join(export_dir, "video.mp4"), path)
+                src = os.path.join(export_dir, "video.mp4")
+                try:
+                    os.rename(src, path)
+                except OSError as e:
+                    if getattr(e, 'errno', None) == 18:  # Invalid cross-device link
+                        print("Cross-device link error detected, using shutil.copy2 as fallback.")
+                        shutil.copy2(src, path)
+                        os.remove(src)
+                    else:
+                        raise
 
             print(f"Video Done")
             print("Cleaning up...")

--- a/piano_visualizer/__init__.py
+++ b/piano_visualizer/__init__.py
@@ -262,107 +262,167 @@ class Video:
         surf = pygame.Surface(self.resolution, pygame.SRCALPHA)
         surf.fill((0, 0, 0, 0))
         width, height = self.resolution
-        max_height = height/5
         min_height = height/12
-        whitekey_height = min(max_height, max(
-            min_height, (height-100)/(len(self.pianos)+2)))
-        blackkey_height = whitekey_height/2
-        blackkey_width_factor = 3/4
-        offset = height/len(self.pianos)
-        p_height = offset
+        p_height = height/len(self.pianos)
         p_width = width
-        whitekey_width = width/(88*7/12) - 1
+        num_white_keys = 52
+        gap = 2
+        # calculates keys dimensions based on actual piano proportions and video resolution
+        total_seps = (num_white_keys - 1) * gap
+        ideal_keys_width = width - total_seps
+        whitekey_width = int(ideal_keys_width // num_white_keys)
+        actual_whitekey_height = whitekey_width * 6
+        whitekey_height = min(actual_whitekey_height, max(min_height, height/(len(self.pianos)+2)))
+        blackkey_width = whitekey_width * 0.65
+        blackkey_height = whitekey_height * 0.65
+        blackkey_x_offsets = [0, 0.65, 0, 0.35, 0, 0, 0.75, 0, 0.5, 0, 0.3, 0]
+        used_width = whitekey_width * num_white_keys + total_seps
+        margin = (width - used_width) // 2
 
         for i, piano in enumerate(self.pianos):
-            p_y = offset * i
+            p_y = p_height * i
             piano.render(surf, frame, p_y, p_width, p_height, whitekey_height,
-                         blackkey_height, whitekey_width, whitekey_width * blackkey_width_factor, 1)
+                         blackkey_height, whitekey_width, blackkey_width, gap, blackkey_x_offsets, margin)
 
         return surf
 
-
 class Piano:
-    def __init__(self, midis=[], blocks=True, color="rainbow"):
+    def __init__(self, midis=[], blocks=True, color="rainbow", no_gradient=False, realistic_render=False):
         self.midis = list(midis)
         self.blocks = bool(blocks)
         self.block_speed = 200
         self.block_rounding = 5
-        self.color = color.lower()
+        self.white_key_rounding = 3
+        self.color = color
+        self.no_gradient = no_gradient
+        self.realistic_render = realistic_render
         self.notes = []
         self.fps = None
         self.offset = None
-        self.block_col = (255, 255, 255)
-        self.white_hit_col = (255, 0, 0)
+        self.block_col = (255, 255, 255) if color == "rainbow" else color
+        self.white_hit_col = (255, 0, 0) if color == "rainbow" else color
         self.white_col = (255, 255, 255)
-        self.black_hit_col = (255, 0, 0)
-        self.black_col = (0, 0, 0)
+        self.black_hit_col = (255, 0, 0) if color == "rainbow" else color
+        self.black_col = (20, 20, 20)
 
     def configure(self, datapath, value):
         if datapath in self.__dict__.keys():
             setattr(self, datapath, value)
 
-    def render_rect(self, surf, x, y, width, height, color):
+    def render_key(self, surf, x, y, width, height, color, is_black, gap):
+        bottom_rounding = 0 if is_black or not self.realistic_render else self.white_key_rounding
+        if is_black:
+            #  draw black key borders
+            pygame.draw.rect(surf, self.black_col, (x, y, width, height))
+            # define black key size (without borders)
+            x += 1 + gap // 2
+            width = max(0, width - 2 - gap)
+            height = max(0, height - gap)
+        else:
+            # draw white key background
+            pygame.draw.rect(surf, self.white_col, (x, y, width, height), \
+                border_top_left_radius=0, border_top_right_radius=0, \
+                border_bottom_left_radius=bottom_rounding, border_bottom_right_radius=bottom_rounding)
+
         s = pygame.Surface((width, height), pygame.SRCALPHA)
-        for cy in range(int(height+1)):
-            pygame.draw.rect(s, list(color) + [255*((height-cy)/height)], (0, cy, width, 1))
+
+        if self.no_gradient:
+            pygame.draw.rect(surf, color, (x, y, width, height), \
+                border_top_left_radius=0, border_top_right_radius=0, \
+                border_bottom_left_radius=bottom_rounding, border_bottom_right_radius=bottom_rounding)
+        else:
+            for cy in range(int(height+1)):
+                pygame.draw.rect(s, list(color) + [255*((height-cy)/height)], (0, cy, width, 1))
+
         surf.blit(s, (x, y))
 
-    def render(self, surf, frame, y, width, height, wheight, bheight, wwidth, bwidth, gap):
-        counter = 0
-        playing_keys = self.get_play_status(frame)
-        black_keys = []
+    def render(self, surf, frame, y, width, height, wheight, bheight, wwidth, bwidth, gap, blackkey_x_offsets, margin=0):
+        # num_white_keys = 52
+        key_xs = [0]*88
+        white_xs = []
+        white_indices = [None]*88
+        white_index = 0
+        for key in range(88):
+            if not self.is_black(key):
+                key_xs[key] = margin + white_index*(wwidth + gap)
+                white_xs.append(key_xs[key])
+                white_indices[key] = white_index
+                white_index += 1
+            else:
+                # black key position according to surrounding white keys
+                left_index = key - 1
+                if left_index >= 0 and white_indices[left_index] is not None:
+                    key_xs[key] = key_xs[left_index] + wwidth - (bwidth * blackkey_x_offsets[self.get_black_key_scale_index(key)]) + gap
+                else:
+                    key_xs[key] = 0
+
+        # render falling notes
         if self.blocks:
-            self.render_blocks(surf, frame, y, width, height - wheight, wwidth, bwidth, gap)
+            self.render_blocks(surf, frame, y, width, height - wheight , wwidth, bwidth, gap, key_xs)
+
         py = y + height - wheight
+        # fill black background under piano (for margins around centered keyboard)
         surf.fill((0, 0, 0), (0, py, width, wheight))
 
+        playing_keys = self.get_play_status(frame)
+
+        # draw all white keys
         for key in range(88):
+            x = key_xs[key]
+            # i = 0
+            if not self.is_black(key):
+                # white keys
+                color = self.get_rainbow(x, width) if (key in playing_keys and self.color == "rainbow") else (self.white_hit_col if key in playing_keys else self.white_col)
+                self.render_key(surf, x, py, wwidth, wheight, color, False, gap)
+
+        # draw all black keys
+        for key in range(88):
+            x = key_xs[key]
             if self.is_black(key):
-                x = (counter+1)*(wwidth + gap) - gap/2 - bwidth/2
+                # black keys
                 if key in playing_keys:
-                    color = self.get_rainbow(
-                        x, width) if self.color == "rainbow" else self.black_hit_col
+                    color = self.get_rainbow(x, width) if self.color == "rainbow" else self.black_hit_col
+                    self.render_key(surf, x, py, bwidth, bheight, color, True, gap)
                 else:
                     color = self.black_col
-                black_keys.append(
-                    ((surf, self.black_col, (x, py, bwidth, bheight)), (surf, x, py, bwidth, bheight, color)))
-            else:
-                counter += 1
-                x = counter*(wwidth + gap)
-                if key in playing_keys:
-                    color = self.get_rainbow(
-                        x, width) if self.color == "rainbow" else self.white_hit_col
-                else:
-                    color = self.white_col
-                pygame.draw.rect(surf, self.white_col, (x, py, wwidth, wheight))
-                self.render_rect(surf, x, py, wwidth, wheight, color)
+                    self.render_key(surf, x, py, bwidth, bheight, color, True, gap)
+                    if self.realistic_render:
+                        bevel_color = (70, 70, 70)
+                        bevel_s_color = (60, 60, 60)
+                        bevel_b = 4
+                        bevel_r = 6
+                        bevel_w = max(0, bwidth - bevel_b)
+                        bevel_w_s = 2
+                        bevel_h = bheight * 0.1
+                        bevel_h_s = bheight - 2
+                        bevel_x = x + bevel_b / 2
+                        bevel_x_sl = x + bwidth - bevel_b
+                        bevel_x_sr = x + bevel_b / 2
+                        bevel_y = py + bheight - bevel_h - 3
+                        bevel_y_s = py
+                        pygame.draw.rect(surf, bevel_color, (bevel_x, bevel_y, bevel_w, bevel_h), \
+                            border_top_left_radius=bevel_r, border_top_right_radius=bevel_r, \
+                            border_bottom_left_radius=0, border_bottom_right_radius=0)
+                        pygame.draw.rect(surf, bevel_s_color, (bevel_x_sl, bevel_y_s, bevel_w_s, bevel_h_s))
+                        pygame.draw.rect(surf, bevel_s_color, (bevel_x_sr, bevel_y_s, bevel_w_s, bevel_h_s))
 
-        for key in black_keys:
-            pygame.draw.rect(*key[0])
-            self.render_rect(*key[1])
-
-    def render_blocks(self, surf, frame, y, width, height, wwidth, bwidth, gap):
+    # falling notes
+    def render_blocks(self, surf, frame, y, width, height, wwidth, bwidth, gap, key_xs):
         for note in self.notes:
             bottom = (frame - note["start"]) * \
                 self.block_speed / self.fps + y + height
             top = bottom - (note["end"] - note["start"]) * \
                 self.block_speed / self.fps
             if top <= y + height and bottom >= y:
-                x = self.get_key_x(note["note"], wwidth, gap, bwidth)
-                pygame.draw.rect(surf, self.get_rainbow(x, width) if self.color == "rainbow" else self.block_col, (
-                    x, top, bwidth if self.is_black(note["note"]) else wwidth, bottom-top), border_radius=self.block_rounding)
-
-    def get_key_x(self, key, wwidth, gap, bwidth):
-        counter = 1
-
-        for k in range(key):
-            if not self.is_black(k):
-                counter += 1
-
-        if self.is_black(key):
-            return counter*(wwidth + gap) - gap/2 - bwidth/2
-        else:
-            return counter*(wwidth + gap)
+                key = note["note"]
+                x = key_xs[key]
+                w = wwidth
+                color = self.get_rainbow(x, width) if self.color == "rainbow" else self.block_col
+                if self.is_black(key):
+                    x = x + 1 + gap // 2
+                    w = max(0, bwidth - 2 - gap)
+                pygame.draw.rect(surf, color, (
+                        x, top, w, bottom-top), border_radius=self.block_rounding)
 
     def get_rainbow(self, x, width):
         rgb = hsv_to_rgb(((x/width)*255, 255, 255))
@@ -393,8 +453,13 @@ class Piano:
                             else:
                                 start_keys[msg.note - 21] = int(frame)
 
+    def get_black_key_scale_index(self, key):
+        # offset 3 notes to align MIDI A0 with a C
+        return (key - 3) % 12
+
     def is_black(self, key):
-        return (key - 3) % 12 in (1, 3, 6, 8, 10)
+        key_scale_index = self.get_black_key_scale_index(key)
+        return key_scale_index in (1, 3, 6, 8, 10)
 
     def get_play_status(self, frame):
         keys = set()


### PR DESCRIPTION
## Fixes

- Wrong MIDI tempo interpretation and video length 
- Keep start and trailing silence if present in MIDI file
- Inverted colors due to Pygame in RGB but OpenCV in BGR (rainbow colors for falling notes have been kept)
- Allow video saving to other location than the program's root directory (another HDD for instance)

## Enhancements

- Piano keyboard now have proper dimension (white and black keys have correct relative sizes and positioning)
- Add "realistic" keyboard rendering (rounded white keys and speculars on black keys)
- Options to specify blocks and played keys colors
- Options to export keyboard only (proper video height automaticaly calculated)

## Misc

- Refactor rendering logic for readability and maintenance (and slight draw calls optimisation)
- Update readme with new options